### PR TITLE
Set up Cursor Cloud dev environment (Nix + aarch64 emulation)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,72 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is a **Nix flake** that builds a NixOS system for a **Raspberry Pi 4
+(`aarch64-linux`)**. There is no long-running app to serve; "running the
+application" means building the NixOS system configuration (`toplevel`) and,
+optionally, the SD-card image. See `README.md` and `.github/workflows/ci.yaml`
+for the canonical build targets.
+
+### Key fact: cross-architecture builds
+
+The cloud VM is `x86_64-linux`, but every flake output targets `aarch64-linux`.
+Builds therefore rely on `aarch64` emulation via QEMU + `binfmt_misc`. QEMU
+(`/usr/bin/qemu-aarch64-static`) is installed in the VM snapshot, and the update
+script re-registers the `binfmt_misc` interpreter on each boot (that registration
+is runtime state and does not survive a reboot).
+
+### Session start: start the Nix daemon (required, not in update script)
+
+Nix is installed multi-user with **no init system**, so the daemon is not started
+automatically. Start it once per session before running any `nix` command:
+
+```bash
+# daemon (background service — leave it running)
+[ -S /nix/var/nix/daemon-socket/socket ] || sudo /nix/var/nix/profiles/default/bin/nix-daemon &
+```
+
+A convenient way to keep it alive is a dedicated tmux session:
+`tmux new-session -d -s nix-daemon -- sudo /nix/var/nix/profiles/default/bin/nix-daemon`.
+
+Login shells already source `/etc/profile.d/nix.sh`, so `nix` is on `PATH`
+automatically in new shells. Flakes and `nix-command` are enabled globally.
+
+### aarch64 emulation (handled by the update script, but here for reference)
+
+If `nix build` fails with an "Exec format error" for `aarch64` builds, the
+`binfmt_misc` registration is missing. Re-run:
+
+```bash
+sudo mountpoint -q /proc/sys/fs/binfmt_misc || sudo mount -t binfmt_misc binfmt_misc /proc/sys/fs/binfmt_misc
+echo ':qemu-aarch64:M::\x7fELF\x02\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\xb7\x00:\xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff:/usr/bin/qemu-aarch64-static:OCF' | sudo tee /proc/sys/fs/binfmt_misc/register
+```
+
+The `F` (fix-binary) flag is important: it makes emulation work inside the Nix
+build sandbox.
+
+### Binary caches
+
+`/etc/nix/nix.custom.conf` adds `aarch64-linux` to `extra-platforms` and trusts
+the `nixos-raspberrypi.cachix.org` substituter (matching the flake's `nixConfig`).
+The flake's own `nixConfig` substituters are ignored unless you pass
+`--accept-flake-config`; the system config already covers them, so this warning
+is harmless.
+
+### Lint / check / build commands
+
+- Evaluate + lint the whole flake (fast, no full builds):
+  `nix flake check --all-systems`
+- Build the NixOS system (the primary CI target):
+  `nix build .#nixosConfigurations.rpi.config.system.build.toplevel`
+- Build the bootable SD image (heavy; large disk + long emulated build):
+  `nix build .#rpi4-image`
+
+### Gotchas
+
+- `home-assistant` is pulled from `nixpkgs-unstable` with a `paho-mqtt`
+  `doCheck = false` overlay (`overlays/paho-mqtt.nix`). This changes its closure
+  hash, so it is **not in any binary cache and is rebuilt from source under
+  emulation** on the first `toplevel` build (slow, but mostly file-copying, not
+  compilation). Subsequent builds hit the local `/nix/store`.
+- Do not commit the `result` symlink created by `nix build`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up a working development environment for this Raspberry Pi 4 NixOS flake inside a Cursor Cloud VM and documents how future agents can reproduce it. The VM is `x86_64-linux` while every flake output targets `aarch64-linux`, so the setup relies on QEMU + `binfmt_misc` emulation.

The only repo change is a new `AGENTS.md` (documentation). No application/config code was modified.

## What was set up in the VM

- Installed Nix (Determinate Nix, flakes + `nix-command` enabled).
- Configured `aarch64-linux` in `extra-platforms` and trusted the `nixos-raspberrypi.cachix.org` substituter.
- Installed `qemu-user-static` and registered the `aarch64` `binfmt_misc` interpreter with the `F` (fix-binary) flag so emulation works inside the Nix build sandbox.

The **update script** (registered separately) only re-registers the `aarch64` `binfmt_misc` interpreter on each boot (runtime state that does not persist), guarded to be idempotent and non-breaking. Starting the `nix-daemon` is a background service, so it lives in `AGENTS.md` rather than the update script.

## Verification (end to end)

| Step | Command | Result |
| --- | --- | --- |
| Lint / check | `nix flake check --all-systems` | passes (evaluates all outputs) |
| Build (hello world) | `nix build .#nixosConfigurations.rpi.config.system.build.toplevel` | builds the full Pi 4 NixOS system (aarch64 binaries) |
| Run | built `hass --version` under emulation | prints `2026.7.2` |

The built system's `systemd` is a genuine `ELF 64-bit ... ARM aarch64` binary, and the Home Assistant binary this config deploys actually executes under emulation.

Note: `home-assistant` is rebuilt from source on the first `toplevel` build (a `paho-mqtt` overlay changes its closure hash so it misses the binary caches); this is slow but expected and cached locally afterward.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-69090e27-ece2-4c50-bf7c-b8fb88cd1b12?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-69090e27-ece2-4c50-bf7c-b8fb88cd1b12&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

