### PR TITLE
fix(home): use nix4nvchad homeManagerModules output

### DIFF
--- a/home/nvchad.nix
+++ b/home/nvchad.nix
@@ -8,7 +8,7 @@ in
     prettier
   ];
 
-  imports = [ inputs.nix4nvchad.homeManagerModule ];
+  imports = [ inputs.nix4nvchad.homeManagerModules.default ];
 
   programs.nvchad = {
     enable = true;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The lock file maintenance update bumped `nix4nvchad`, which renamed its flake output from `homeManagerModule` to `homeManagerModules`. That broke evaluation of `nixosConfigurations.rpi`.

## Changes

- Update `home/nvchad.nix` to import `inputs.nix4nvchad.homeManagerModules.default` instead of the removed `homeManagerModule` attribute.

## Verification

- Rebased onto the latest `renovate/lock-file-maintenance` (uses the new `flake.lock`)
- `nix flake check --all-systems` passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c3279e24-3499-4bca-ac6c-6c46b9673568?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c3279e24-3499-4bca-ac6c-6c46b9673568&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

