### PR TITLE
fix: provide sealed.replacePlaceholders for tmux module

### DIFF
--- a/flakes/nixosConfig.nix
+++ b/flakes/nixosConfig.nix
@@ -29,6 +29,7 @@ let
           pkgs-unstable
           meta
           ;
+        sealed = lib.sealed;
       }
       // extraSpecialArgs;
       homeManagerInjection = lib.injectHomeManager {

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,3 +1,4 @@
 {
   injectHomeManager = import ./injectHomeManager.nix;
+  sealed = import ./sealed.nix;
 }

--- a/lib/sealed.nix
+++ b/lib/sealed.nix
@@ -1,0 +1,8 @@
+{
+  replacePlaceholders =
+    replacements: text:
+    builtins.foldl' (
+      acc: name:
+      builtins.replaceStrings [ name ] [ replacements.${name} ] acc
+    ) text (builtins.attrNames replacements);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`nix flake check` failed evaluating `nixosConfigurations.rpi` because `home/tmux/default.nix` expects a `sealed` module argument that was never provided:

```
error: attribute 'sealed' missing
```

The tmux refactor in d7da8d5 moved config into `home/tmux/tmux.conf` with `@placeholder@` tokens, but the `sealed.replacePlaceholders` helper was never added.

## Fix

- Add `lib/sealed.nix` with `replacePlaceholders`, which substitutes placeholder tokens in a string from an attribute set.
- Export it from `lib/default.nix`.
- Pass `sealed` through `specialArgs` in `flakes/nixosConfig.nix` so home-manager modules can use it.

## Verification

```
nix flake check --all-systems
```

Both `nixosConfigurations.rpi` and `packages.aarch64-linux.rpi4-image` evaluate successfully.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a3086620-70b7-49ce-84ea-4c0b1ec34422?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a3086620-70b7-49ce-84ea-4c0b1ec34422&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

