### PR TITLE
fix(ci): stop rebuilding linux_rpi from source on every CI run

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,23 +23,23 @@ jobs:
         uses: nix-community/cache-nix-action@v7
         with:
           # restore and save a cache using this key
-          primary-key: nix-ubuntu-24.04-arm-rpi-${{ hashFiles('**/*.nix') }}
+          primary-key: nix-ubuntu-24.04-arm-rpi-${{ hashFiles('**/*.nix', 'flake.lock') }}
           # if there's no cache hit, restore a cache by this prefix
           restore-prefixes-first-match: nix-ubuntu-24.04-arm-rpi
-          # collect garbage until Nix store size (in bytes) is at most this number
-          # before trying to save a new cache
-          gc-max-store-size-linux: 1073741824
+          # Keep enough of the store to retain linux_rpi across runs (~8 GiB).
+          # The previous 1 GiB cap threw away the vendor kernel after each job.
+          gc-max-store-size-linux: 8589934592
           # do purge caches
           purge: true
           # purge all versions of the cache
-          purge-prefixes: cache-ubuntu-24.04-arm-rpi
+          purge-prefixes: nix-ubuntu-24.04-arm-rpi
           # created more than this number of seconds ago relative to the start of the `Post Restore` phase
           purge-created: 0
           # except the version with the `primary-key`, if it exists
           purge-primary-key: never
 
       - name: Build TopLevel / rpi
-        run: nix build .#nixosConfigurations.rpi.config.system.build.toplevel
+        run: nix --accept-flake-config build .#nixosConfigurations.rpi.config.system.build.toplevel
 
   build-rpi4-image:
     runs-on: ubuntu-24.04-arm
@@ -55,20 +55,19 @@ jobs:
         uses: nix-community/cache-nix-action@v7
         with:
           # restore and save a cache using this key
-          primary-key: nix-ubuntu-24.04-arm-rpi4-image-${{ hashFiles('**/*.nix') }}
+          primary-key: nix-ubuntu-24.04-arm-rpi4-image-${{ hashFiles('**/*.nix', 'flake.lock') }}
           # if there's no cache hit, restore a cache by this prefix
           restore-prefixes-first-match: nix-ubuntu-24.04-arm-rpi4-image
-          # collect garbage until Nix store size (in bytes) is at most this number
-          # before trying to save a new cache
-          gc-max-store-size-linux: 1073741824
+          # Keep enough of the store to retain linux_rpi across runs (~8 GiB).
+          gc-max-store-size-linux: 8589934592
           # do purge caches
           purge: true
           # purge all versions of the cache
-          purge-prefixes: cache-ubuntu-24.04-arm-rpi4-image
+          purge-prefixes: nix-ubuntu-24.04-arm-rpi4-image
           # created more than this number of seconds ago relative to the start of the `Post Restore` phase
           purge-created: 0
           # except the version with the `primary-key`, if it exists
           purge-primary-key: never
 
       - name: Build SD image
-        run: nix build .#rpi4-image
+        run: nix --accept-flake-config build .#rpi4-image

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,4 +69,9 @@ is harmless.
   hash, so it is **not in any binary cache and is rebuilt from source under
   emulation** on the first `toplevel` build (slow, but mostly file-copying, not
   compilation). Subsequent builds hit the local `/nix/store`.
+- Vendor `linux_rpi` comes from `nixos-raspberrypi.cachix.org`, not
+  `cache.nixos.org`. Keep the flake input on a pin that still has the kernel
+  in that cache (stale `nixos-26.05` pins age out). Do not re-enable
+  `boot.supportedFilesystems.zfs` unless you need it: `sd-image`/`profiles.base`
+  defaults it on for aarch64 and that pulls an uncached `zfs-kernel` build.
 - Do not commit the `result` symlink created by `nix build`.

--- a/flake.lock
+++ b/flake.lock
@@ -222,16 +222,16 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1783460971,
-        "narHash": "sha256-jORGvBH+uTyVirtfpcA22QiUrJnIQcHo6zs1qS5aDSs=",
+        "lastModified": 1785596452,
+        "narHash": "sha256-KT/OleUMpSKsWgi0eTuqS/0GD4ucPQcvLgmvlw8ZuCM=",
         "owner": "nvmd",
         "repo": "nixos-raspberrypi",
-        "rev": "16e7150a4aea0578871ed6ffeb6a5c121bcee441",
+        "rev": "7e39508bcf9c1da82cf11c1e22f74f9d9fd0fe10",
         "type": "github"
       },
       "original": {
         "owner": "nvmd",
-        "ref": "nixos-26.05",
+        "ref": "main",
         "repo": "nixos-raspberrypi",
         "type": "github"
       }
@@ -285,11 +285,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1783148766,
-        "narHash": "sha256-uslt2pqShTIXDdAHRHv2QkYLsVdY8Oqwz0EA48/RSM8=",
+        "lastModified": 1784856561,
+        "narHash": "sha256-J+Bx1Z6Oeoj2FgnBhRMKyUhhtDoOpTgXYaVLZpDjW4A=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a50de1b7d8a586adc18d2395c19de7d6058e6030",
+        "rev": "597283ad8aa0b331c788e97c4c262d58877074ef",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -9,8 +9,11 @@
       url = "github:nix-community/home-manager/release-26.05";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    # Track main: the nixos-26.05 branch is frozen on a July pin whose
+    # linux_rpi4 build has already aged out of nixos-raspberrypi.cachix.org.
+    # main (and develop) still have substitutable vendor kernels.
     nixos-raspberrypi = {
-      url = "github:nvmd/nixos-raspberrypi/nixos-26.05";
+      url = "github:nvmd/nixos-raspberrypi/main";
     };
     nix4nvchad = {
       url = "github:nix-community/nix4nvchad";

--- a/system/boot.nix
+++ b/system/boot.nix
@@ -1,7 +1,12 @@
+{ lib, ... }:
 {
   boot.loader.grub.enable = false;
-  # Recommended default from 26.11; silence the 26.05 deprecation warning.
-  boot.zfs.forceImportRoot = false;
+
+  # sd-image pulls in profiles.base, which defaults zfs=true on aarch64.
+  # Root is ext4; keeping ZFS enabled forces zfs-kernel (and often a full
+  # linux_rpi rebuild) that is not in nixos-raspberrypi.cachix.org.
+  # See https://github.com/nvmd/nixos-raspberrypi/issues/172
+  boot.supportedFilesystems.zfs = lib.mkForce false;
 
   # This fix the problem that rpi fail to reconnect to wifi after reboot in a fresh nixos-rebuild
   # See https://github.com/Robertof/nixos-docker-sd-image-builder/issues/10#issuecomment-646901392


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

CI `build-toplevel` was spending ~1h40m compiling `linux_rpi-bcm2711` because the vendor kernel was not substituted from `nixos-raspberrypi.cachix.org`.

## Causes

1. `sd-image` → `profiles.base` defaults `boot.supportedFilesystems.zfs = true` on aarch64 even though root is ext4.
2. Flake tracked `nixos-raspberrypi/nixos-26.05`, frozen on a July pin whose `linux_rpi4` narinfo is now **404** on cachix. `main` still has a live kernel.
3. Actions Nix store cache used a 1 GiB GC cap and a mismatched purge prefix, so the kernel did not survive across runs.

## Changes

- Force-disable ZFS in `system/boot.nix`
- Point `nixos-raspberrypi` at `main` and update the lock
- Raise CI store cache size, include `flake.lock` in the key, fix purge prefixes, pass `--accept-flake-config`
- Document the footgun in `AGENTS.md`

## Verification

- `boot.supportedFilesystems.zfs` → `false`
- System kernel path matches `linux_rpi4` and has **HTTP 200** on `nixos-raspberrypi.cachix.org`:
  `/nix/store/w4a7jcdzppyg59wg8jpj50m4dk12hzzi-linux_rpi-bcm2711-6.18.34-unstable_20260604`
- `nix build --dry-run` of toplevel:
  - **fetches** the vendor `linux_rpi` kernel + modules
  - only **builds** config-specific `modules-shrunk` + `initrd` (seconds, not ~1h40m)
  - no `zfs-kernel` in the plan
- `nix flake check --all-systems` passes

## Test plan

- [x] Confirm `boot.supportedFilesystems.zfs == false`
- [x] Confirm system kernel store path has a live cachix narinfo (HTTP 200)
- [x] Confirm dry-run does **not** list full `linux_rpi-*.drv` under “will be built”
- [x] `nix flake check --all-systems`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9e24c0bc-f41e-4a73-90c8-4e40919e9221?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9e24c0bc-f41e-4a73-90c8-4e40919e9221&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

